### PR TITLE
fixing disabled button "Previous"

### DIFF
--- a/lib/DiscordMusicBot.js
+++ b/lib/DiscordMusicBot.js
@@ -554,8 +554,8 @@ class DiscordMusicBot extends Client {
         .setEmoji("⏮️")
         .setDisabled(
           !player.queue.previous ||
-            player.queue.previous !== player.queue.current ||
-            player.queue.previous !== player.queue[0]
+            player.queue.previous === player.queue.current ||
+            player.queue.previous === player.queue[0]
             ? true
             : false
         ),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Because of a typo in 45411a45e081346e46be58db722466aff7845910 button "Previous" currently is permanently disabled. This pull request fixes the typo.

